### PR TITLE
Fix version conflicts caused by PR#110

### DIFF
--- a/Herald.MessageQueue.Sqs/Herald.MessageQueue.Sqs.csproj
+++ b/Herald.MessageQueue.Sqs/Herald.MessageQueue.Sqs.csproj
@@ -7,8 +7,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.102.108" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.0.36" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Herald.MessageQueue\Herald.MessageQueue.csproj" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump AWSSDK.SQS from 3.3.102.108 to 3.7.0.36. [(PR#110)](https://github.com/tcfialho/Herald.MessageQueue/pull/110).
Hope this fix can help you.

Best regards,
sucrose
